### PR TITLE
remove reference to @apollo/federation

### DIFF
--- a/content/graphql/federation.md
+++ b/content/graphql/federation.md
@@ -18,7 +18,7 @@ In the following sections, we'll set up a demo application that consists of a ga
 Start by installing the required dependencies:
 
 ```bash
-$ npm install --save @apollo/federation @apollo/subgraph
+$ npm install --save @apollo/subgraph
 ```
 
 #### Schema first


### PR DESCRIPTION
it's deprecated in favor of either:

- @apollo/subgraph
- @apollo/composition

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/docs.nestjs.com/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Docs
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
